### PR TITLE
feat: add webhook method response support for Telegram bots

### DIFF
--- a/internal/server/control_handler.go
+++ b/internal/server/control_handler.go
@@ -321,6 +321,10 @@ func (h *ControlHandler) injectTokenUpdate(w http.ResponseWriter, r *http.Reques
 		if result.Error != "" {
 			response["error"] = result.Error
 		}
+		// Include method result if webhook returned a method call
+		if result.MethodResult != nil {
+			response["method_result"] = result.MethodResult
+		}
 		json.NewEncoder(w).Encode(response)
 	} else {
 		// Queue for polling

--- a/internal/server/responder.go
+++ b/internal/server/responder.go
@@ -4,6 +4,7 @@ package server
 import (
 	"github.com/watzon/tg-mock/gen"
 	"github.com/watzon/tg-mock/internal/faker"
+	"github.com/watzon/tg-mock/internal/webhook"
 )
 
 // Responder generates appropriate responses for Bot API methods
@@ -34,7 +35,15 @@ func (r *Responder) GenerateWithOverrides(spec gen.MethodSpec, params, overrides
 	return r.faker.GenerateWithOverrides(returnType, params, overrides), nil
 }
 
+// ExecuteMethod implements the webhook.MethodExecutor interface.
+// It runs a Bot API method with the given parameters and returns the generated response.
+func (r *Responder) ExecuteMethod(spec gen.MethodSpec, params map[string]interface{}) (interface{}, error) {
+	return r.Generate(spec, params)
+}
+
 // GetFaker returns the faker instance for direct access when needed.
 func (r *Responder) GetFaker() *faker.Faker {
 	return r.faker
 }
+
+var _ webhook.MethodExecutor = (*Responder)(nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,7 +54,6 @@ func New(cfg Config) *Server {
 	scenarioEngine := scenario.NewEngine()
 	updateQueue := updates.NewQueue()
 	requestRecorder := inspector.NewRecorder()
-	webhookRegistry := webhook.NewRegistry()
 
 	// Create faker with configured seed
 	f := faker.New(faker.Config{
@@ -63,6 +62,9 @@ func New(cfg Config) *Server {
 
 	// Create responder with faker
 	responder := NewResponder(f)
+
+	// Create webhook registry with responder for method execution
+	webhookRegistry := webhook.NewRegistry(responder)
 
 	// Load tokens from config
 	for token, info := range cfg.Tokens {


### PR DESCRIPTION
## Summary

- Add support for executing Bot API methods returned in webhook responses
- Extend DeliveryResult with MethodResult field to track executed methods
- Add MethodExecutionResult type to capture method execution details
- Implement MethodExecutor interface to avoid circular dependencies
- Parse webhook responses for method calls and execute them automatically
- Include method results in control API responses for testing/debugging
- Add comprehensive test coverage for all edge cases

This enables bots to respond to webhook updates with API method calls
in a single HTTP request, reducing latency from 2 round-trips to 1.

## Test plan

- All existing tests pass
- 9 new tests added covering all webhook method response scenarios:
  - Valid method responses (sendMessage, answerCallbackQuery)
  - Edge cases (empty response, invalid JSON, no method field)
  - Error handling (unknown methods, non-2xx status, nil executor)
- Integration tests verify complete workflow